### PR TITLE
fixed soft-lock caused by DR bonus tooltip text generation

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -567,7 +567,14 @@
 			},
 			"traits": {
 				"desc": "Trait",
-				"points": "Pts"
+				"points": "Pts",
+				"container_type": {
+					"group": "",
+					"meta_trait": "Meta",
+					"attributes": "Attribute",
+					"ancestry": "Ancestry",
+					"alternative_abilities": "Alternate"
+				}
 			},
 			"skills": {
 				"desc": "Skill / Technique",
@@ -932,6 +939,7 @@
 			"container_type": {
 				"group": "Group",
 				"meta_trait": "Meta-Trait",
+				"attributes": "Attributes",
 				"ancestry": "Ancestry",
 				"alternative_abilities": "Alternative Abilities"
 			},

--- a/src/module/actor/character/document.ts
+++ b/src/module/actor/character/document.ts
@@ -1157,7 +1157,7 @@ class CharacterGURPS extends BaseActorGURPS {
 				this.processFeature(e, f, 0)
 			}
 			for (const m of e.deepModifiers) {
-				if (!m.enabled) continue
+				if (m.enabled === false) continue
 				for (const f of m.features) {
 					this.processFeature(e, f, 0)
 				}
@@ -1651,18 +1651,16 @@ class CharacterGURPS extends BaseActorGURPS {
 		tooltip: TooltipGURPS | null = null,
 		drMap: Map<string, number> = new Map()
 	): Map<string, number> {
-		const isTopLevel = this.BodyType.locations.some(e => e.id === locationID)
-
+		let isTopLevel = false
+		for (const location of this.BodyType.locations) {
+			if (location.id === locationID) {
+				isTopLevel = true
+				break
+			}
+		}
 		for (const f of this.features.drBonuses) {
-			if (f.type === FeatureType.DRBonus &&
-				(
-					(f.location === gid.All && isTopLevel) ||
-					equalFold(locationID, f.location)
-				)
-			) {
-				const current = drMap.has(f.specialization!.toLowerCase())
-					? drMap.get(f.specialization!.toLowerCase()) || 0
-					: 0
+			if ((f.location === gid.All && isTopLevel) || equalFold(locationID, f.location)) {
+				const current = drMap.get(f.specialization!.toLowerCase()) ?? 0
 				drMap.set(f.specialization!.toLowerCase(), current + f.adjustedAmount)
 				f.addToTooltip(tooltip)
 			}

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -371,6 +371,7 @@ const GURPSCONFIG: CONFIG["GURPS"] = {
 			[TraitContainerType.Group]: "gurps.select.container_type.group",
 			[TraitContainerType.MetaTrait]: "gurps.select.container_type.meta_trait",
 			[TraitContainerType.Ancestry]: "gurps.select.container_type.ancestry",
+			[TraitContainerType.Attributes]: "gurps.select.container_type.attributes",
 			[TraitContainerType.AlternativeAbilities]: "gurps.select.container_type.alternative_abilities",
 		},
 		difficulty: {

--- a/src/module/feature/dr_bonus.ts
+++ b/src/module/feature/dr_bonus.ts
@@ -15,8 +15,8 @@ export class DRBonus extends BaseFeature {
 	}
 
 	addToTooltip(buffer: TooltipGURPS | null): void {
-		if (buffer) {
-			let item: Item | null | undefined = this.item
+		if (buffer !== null) {
+			let item: any | null | undefined = this.item
 			if (item?.actor)
 				while (
 					[
@@ -26,7 +26,7 @@ export class DRBonus extends BaseFeature {
 						ItemType.EquipmentModifierContainer,
 					].includes(item?.type as any)
 				) {
-					if (item?.parent instanceof Item) item = item?.parent
+					if (item?.container instanceof Item) item = item?.container
 				}
 			if (this.per_level)
 				buffer.push(

--- a/src/module/item/base/document.ts
+++ b/src/module/item/base/document.ts
@@ -21,12 +21,6 @@ class BaseItemGURPS extends Item {
 		}
 	}
 
-	// override delete(context?: DocumentModificationContext | undefined): Promise<any> {
-	// 	if (!(this.parent instanceof Item)) return super.delete(context)
-	// 	return this.container?.deleteEmbeddedDocuments("Item", [this.id!])
-	// }
-	//
-
 	static override async createDialog(
 		data: { folder?: string } = {},
 		options: Partial<FormApplicationOptions> = {}

--- a/src/module/item/trait_container/data.ts
+++ b/src/module/item/trait_container/data.ts
@@ -20,5 +20,6 @@ export enum TraitContainerType {
 	Group = "group",
 	MetaTrait = "meta_trait",
 	Ancestry = "ancestry",
+	Attributes = "attributes",
 	AlternativeAbilities = "alternative_abilities",
 }

--- a/src/templates/actor/character/sections/trait.hbs
+++ b/src/templates/actor/character/sections/trait.hbs
@@ -13,9 +13,9 @@
 		{{/if}}
 	</div>
 	<div class="name">
-		<div class="name2">{{this.formattedName}}</div>
+		<div class="name">{{this.formattedName}}</div>
 		<div class="container-type">
-{{#if (and this.isContainer (ne this.system.container_type "group"))}}{{localize (concat "gurps.select.container_type." this.system.container_type)}}{{/if}}</div>
+{{#if (and this.isContainer (ne this.system.container_type "group"))}}{{localize (concat "gurps.character.traits.container_type." this.system.container_type)}}{{/if}}</div>
 	</div>
 	{{{this.notes}}}
 </div>


### PR DESCRIPTION
- reworked HitLocations getter to include nested hit locations, changed how body plan on charsheet is displayed
- added incomplete weapon parsing and attribute parsing to mook gen
- fixed legacy character sheet styling and import bugs related to empty sets
- console.log cleanup
- fixed soft-lock caused by DR bonus tooltip generation